### PR TITLE
fix: delimiter dropdown

### DIFF
--- a/src/utils/editor.js
+++ b/src/utils/editor.js
@@ -73,7 +73,7 @@ export const openEditor = function (cell, empty, e) {
                 // Get current value
                 let value = obj.options.data[y][x];
                 if (obj.options.columns[x].multiple && !Array.isArray(value)) {
-                    value = value.split(';');
+                    value = value.split(obj.options.columns[x].delimiter || ';');
                 }
 
                 // Create dropdown
@@ -297,7 +297,10 @@ export const closeEditor = function (cell, save) {
             ) {
                 // Do nothing
             } else if (obj.options.columns && obj.options.columns[x] && obj.options.columns[x].type == 'dropdown') {
-                value = cell.children[0].dropdown.close(true);
+                const dropdown = cell.children[0].dropdown;
+                const delimiter = obj.options.columns[x].delimiter;
+                dropdown.close(true);
+                value = delimiter && obj.options.columns[x].multiple ? dropdown.getValue(true).join(delimiter) : dropdown.getValue();
             } else if (obj.options.columns && obj.options.columns[x] && obj.options.columns[x].type == 'calendar') {
                 value = cell.children[0].calendar.close(true);
             } else if (obj.options.columns && obj.options.columns[x] && obj.options.columns[x].type == 'color') {

--- a/src/utils/internal.js
+++ b/src/utils/internal.js
@@ -341,7 +341,8 @@ const getDropDownValue = function (column, key) {
         }
 
         // Guarantee single multiple compatibility
-        const keys = Array.isArray(key) ? key : ('' + key).split(';');
+        const delimiter = obj.options.columns[column].delimiter || ';';
+        const keys = Array.isArray(key) ? key : ('' + key).split(delimiter);
 
         for (let i = 0; i < keys.length; i++) {
             if (typeof keys[i] === 'object') {
@@ -356,7 +357,8 @@ const getDropDownValue = function (column, key) {
         console.error('Invalid column');
     }
 
-    return value.length > 0 ? value.join('; ') : '';
+    const displayDelimiter = obj.options.columns[column].delimiter || '; ';
+    return value.length > 0 ? value.join(displayDelimiter) : '';
 };
 
 const validDate = function (date) {


### PR DESCRIPTION
Fix dropdown delimiter option for multiple selection

The delimiter column option was not being respected when using type: 'dropdown' with multiple: true. Selected values were always
joined using the hardcoded jSuites internal separator (;) instead of the configured delimiter.

Root cause: Three places in the code had hardcoded ';' instead of reading column.delimiter:
- editor.js — splitting the stored value when opening the editor
- editor.js — joining selected values when saving on close
- internal.js — splitting the stored value when rendering the cell label, and joining for display

Changes:
- When opening the editor, split the current value using the configured delimiter
- When closing the editor, retrieve values as array from jSuites and join with the configured delimiter
- When rendering the cell, split and display using the configured delimiter