### PR TITLE
fix/create-row-headers-out-of-bounds

### DIFF
--- a/src/utils/rows.js
+++ b/src/utils/rows.js
@@ -57,7 +57,7 @@ export const createRow = function (j, data) {
     td.className = 'jss_row';
     row.element.appendChild(td);
 
-    const numberOfColumns = getNumberOfColumns.call(obj);
+    const numberOfColumns = obj.headers.length || getNumberOfColumns.call(obj);
 
     // Data columns
     for (let i = 0; i < numberOfColumns; i++) {


### PR DESCRIPTION
When columns are deleted down to the minimum allowed by minDimensions,
getNumberOfColumns() still returns the configured minimum instead of the
real column count. This caused createRow to loop beyond obj.headers length,
throwing "Cannot read properties of undefined (reading 'style')".

Fix: prefer obj.headers.length as it always reflects the runtime state.